### PR TITLE
Chart "raw": improve regex to split objects in input templates

### DIFF
--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -15,5 +15,5 @@ annotations:
     fingerprint: AF455B903BFED8363C003F9A5E2474CA7617EC66
     url: https://keybase.io/avistotelecom/pgp_keys.asc
   artifacthub.io/changes: |
-  - kind: fixed
-    description: Fix regex to split objects in input templates: only the "---" line separator at the root level will be considered, excluding indented blocks with object parameters containing the "---" string as well (like TLS certificates)
+    - kind: fixed
+      description: Fix regex to split objects in input templates: only the "---" line separator at the root level will be considered, excluding indented blocks with object parameters containing the "---" string as well (like TLS certificates)

--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -14,3 +14,6 @@ annotations:
   artifacthub.io/signKey: |
     fingerprint: AF455B903BFED8363C003F9A5E2474CA7617EC66
     url: https://keybase.io/avistotelecom/pgp_keys.asc
+  artifacthub.io/changes: |
+  - kind: fixed
+    description: Fix regex to split objects in input templates: only the "---" line separator at the root level will be considered, excluding indented blocks with object parameters containing the "---" string as well (like TLS certificates)

--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -16,4 +16,4 @@ annotations:
     url: https://keybase.io/avistotelecom/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix regex to split objects in input templates: only the '---' line separator at the root level will be considered, excluding indented blocks with object parameters containing the '---' string as well (like TLS certificates)
+      description: Fix regex to split objects in input templates: only the "---" line separator will be considered, excluding object parameters containing the "---" string (like TLS certificates)

--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -8,12 +8,12 @@ keywords:
 maintainers:
   - name: Brawdunoir
     email: yann.lacroix@avisto.com
-version: 1.0.2
+version: 2.0.0
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/signKey: |
     fingerprint: AF455B903BFED8363C003F9A5E2474CA7617EC66
     url: https://keybase.io/avistotelecom/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Fix regex to split objects in input templates: only the "---" line separator will be considered, excluding object parameters containing the "---" string (like TLS certificates)
+    - kind: changed
+      description: Improve regex to split objects in input templates: only the "---" line separator at the root level will be considered, excluding indented blocks with object parameters containing the "---" string as well (like TLS certificates). When upgrading to this 2.X.X version, be sure to verify that the templates passed in input only declare Kubernetes manifests aligned at the root level, without any leading indentation.

--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 maintainers:
   - name: Brawdunoir
     email: yann.lacroix@avisto.com
-version: 1.0.1
+version: 1.0.2
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/signKey: |

--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -8,12 +8,12 @@ keywords:
 maintainers:
   - name: Brawdunoir
     email: yann.lacroix@avisto.com
-version: 2.0.0
+version: 1.0.2
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/signKey: |
     fingerprint: AF455B903BFED8363C003F9A5E2474CA7617EC66
     url: https://keybase.io/avistotelecom/pgp_keys.asc
   artifacthub.io/changes: |
-    - kind: changed
-      description: Improve regex to split objects in input templates: only the "---" line separator at the root level will be considered, excluding indented blocks with object parameters containing the "---" string as well (like TLS certificates). When upgrading to this 2.X.X version, be sure to verify that the templates passed in input only declare Kubernetes manifests aligned at the root level, without any leading indentation.
+    - kind: fixed
+      description: Fix regex to split objects in input templates: only the "---" line separator at the root level will be considered, excluding indented blocks with object parameters containing the "---" string as well (like TLS certificates). When upgrading to this version, be sure to verify that the templates passed in input only declare Kubernetes manifests aligned at the root level, without any leading indentation.

--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -16,4 +16,4 @@ annotations:
     url: https://keybase.io/avistotelecom/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix regex to split objects in input templates: only the "---" line separator at the root level will be considered, excluding indented blocks with object parameters containing the "---" string as well (like TLS certificates)
+      description: Fix regex to split objects in input templates: only the '---' line separator at the root level will be considered, excluding indented blocks with object parameters containing the '---' string as well (like TLS certificates)

--- a/charts/raw/templates/ressources.yaml
+++ b/charts/raw/templates/ressources.yaml
@@ -6,7 +6,7 @@
 {{- range $i, $t := .Values.templates }}
 {{ $kubeResources := tpl $t $ }}
 {{/* Match "---" line separator without with potential leading and trailing whitespaces or comment before the end of line */}}
-{{- range regexSplit "(?m)^\\s*---(\\s*#.*)?$" $kubeResources -1 }}
+{{- range regexSplit "(?m)^\\s*---\\s*(#.*)?$" $kubeResources -1 }}
 {{- if . | trim }}
 ---
 {{ merge (. | fromYaml) $template | toYaml }}

--- a/charts/raw/templates/ressources.yaml
+++ b/charts/raw/templates/ressources.yaml
@@ -6,7 +6,7 @@
 {{- range $i, $t := .Values.templates }}
 {{ $kubeResources := tpl $t $ }}
 {{/* Match "---" line separator without leading indentation and with potential trailing whitespaces or comment before the end of line */}}
-{{- range regexSplit "(?m)^---(\\s*#.*)?$" $kubeResources -1 }}
+{{- range regexSplit "(?m)^---\\s*(#.*)?$" $kubeResources -1 }}
 {{- if . | trim }}
 ---
 {{ merge (. | fromYaml) $template | toYaml }}

--- a/charts/raw/templates/ressources.yaml
+++ b/charts/raw/templates/ressources.yaml
@@ -5,7 +5,8 @@
 {{- end }}
 {{- range $i, $t := .Values.templates }}
 {{ $kubeResources := tpl $t $ }}
-{{- range regexSplit "---" $kubeResources -1 }}
+{{/* Match "---" line separator without leading indentation and with potential trailing whitespaces or comment before the end of line */}}
+{{- range regexSplit "(?m)^---(\\s*#.*)?$" $kubeResources -1 }}
 {{- if . | trim }}
 ---
 {{ merge (. | fromYaml) $template | toYaml }}

--- a/charts/raw/templates/ressources.yaml
+++ b/charts/raw/templates/ressources.yaml
@@ -6,7 +6,7 @@
 {{- range $i, $t := .Values.templates }}
 {{ $kubeResources := tpl $t $ }}
 {{/* Match "---" line separator without leading indentation and with potential trailing whitespaces or comment before the end of line */}}
-{{- range regexSplit "(?m)^---(\\s*#.*)?$" $kubeResources -1 }}
+{{- range regexSplit "(?m)^\\s*---(\\s*#.*)?$" $kubeResources -1 }}
 {{- if . | trim }}
 ---
 {{ merge (. | fromYaml) $template | toYaml }}

--- a/charts/raw/templates/ressources.yaml
+++ b/charts/raw/templates/ressources.yaml
@@ -5,8 +5,8 @@
 {{- end }}
 {{- range $i, $t := .Values.templates }}
 {{ $kubeResources := tpl $t $ }}
-{{/* Match "---" line separator without with potential leading and trailing whitespaces or comment before the end of line */}}
-{{- range regexSplit "(?m)^\\s*---\\s*(#.*)?$" $kubeResources -1 }}
+{{/* Match "---" line separator without leading indentation and with potential trailing whitespaces or comment before the end of line */}}
+{{- range regexSplit "(?m)^---(\\s*#.*)?$" $kubeResources -1 }}
 {{- if . | trim }}
 ---
 {{ merge (. | fromYaml) $template | toYaml }}

--- a/charts/raw/templates/ressources.yaml
+++ b/charts/raw/templates/ressources.yaml
@@ -5,7 +5,7 @@
 {{- end }}
 {{- range $i, $t := .Values.templates }}
 {{ $kubeResources := tpl $t $ }}
-{{/* Match "---" line separator without leading indentation and with potential trailing whitespaces or comment before the end of line */}}
+{{/* Match "---" line separator without with potential leading and trailing whitespaces or comment before the end of line */}}
 {{- range regexSplit "(?m)^\\s*---(\\s*#.*)?$" $kubeResources -1 }}
 {{- if . | trim }}
 ---


### PR DESCRIPTION
Issue found when trying to create a ConfigMap containing a certificate bundle with:
```
templates:
  - |
    apiVersion: v1
    kind: ConfigMap
    metadata:
      name: se-ca-bundle
      labels:
        app.kubernetes.io/instance: kube-prometheus-stack
    data:
      se-ca-bundle.crt: {{ .Values.seCertBundle | quote }}

seCertBundle: |
  -----BEGIN CERTIFICATE-----
  xxx
  -----END CERTIFICATE-----
```

The "---" characters in the "-----BEGIN CERTIFICATE-----" are interpreted by the chart as a separator between distinct Kubernetes manifests, thus breaking the rendering of the ConfigMap.