### PR TITLE
raw-configuration: fix invalid resources issued from comment-only YAML fragments

### DIFF
--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
 maintainers:
   - name: Brawdunoir
     email: yann.lacroix@avisto.com
-version: 1.0.2
+version: 1.0.3
 kubeVersion: ">=1.16.0-0"
 annotations:
   artifacthub.io/signKey: |
@@ -16,4 +16,4 @@ annotations:
     url: https://keybase.io/avistotelecom/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Fix regex to split objects in input templates: only the "---" line separator at the root level will be considered, excluding indented blocks with object parameters containing the "---" string as well (like TLS certificates). When upgrading to this version, be sure to verify that the templates passed in input only declare Kubernetes manifests aligned at the root level, without any leading indentation.
+      description: Prevent comment-only sections before the YAML separator "---" from being treated as extra Kubernetes resources when rendering input templates. These extra documents were only containing merged chart's labels and were invalid Kubernetes manifests.

--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -17,3 +17,4 @@ annotations:
   artifacthub.io/changes: |
     - kind: fixed
       description: Prevent comment-only sections before the YAML separator "---" from being treated as extra Kubernetes resources when rendering input templates. These extra documents were only containing merged chart's labels and were invalid Kubernetes manifests.
+      

--- a/charts/raw/Chart.yaml
+++ b/charts/raw/Chart.yaml
@@ -16,5 +16,4 @@ annotations:
     url: https://keybase.io/avistotelecom/pgp_keys.asc
   artifacthub.io/changes: |
     - kind: fixed
-      description: Prevent comment-only sections before the YAML separator "---" from being treated as extra Kubernetes resources when rendering input templates. These extra documents were only containing merged chart's labels and were invalid Kubernetes manifests.
-      
+      description: Prevent comment-only sections before the YAML separator "---" from being treated as extra Kubernetes resources when rendering input templates. These extra documents were only containing merged chart's labels and were invalid Kubernetes manifests.   

--- a/charts/raw/templates/_helpers.tpl
+++ b/charts/raw/templates/_helpers.tpl
@@ -31,8 +31,8 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-raw.resource will create a resource template that can be
-merged with each item in `.Values.resources`.
+raw.resource will create a resource template that will be
+merged with each item in `.Values.resources` and `.Values.templates`.
 */}}
 {{- define "raw.resource" -}}
 metadata:

--- a/charts/raw/templates/ressources.yaml
+++ b/charts/raw/templates/ressources.yaml
@@ -7,9 +7,10 @@
 {{ $kubeResources := tpl $t $ }}
 {{/* Match "---" line separator without leading indentation and with potential trailing whitespaces or comment before the end of line */}}
 {{- range regexSplit "(?m)^---\\s*(#.*)?$" $kubeResources -1 }}
-{{- if . | trim }}
+{{ $document := . | trim | fromYaml }}
+{{- if not (empty $document) }}
 ---
-{{ merge (. | fromYaml) $template | toYaml }}
+{{ merge $document $template | toYaml }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Example of the error:
```
templates:
  - |
    # Create my priority class
    ---
    apiVersion: scheduling.k8s.io/v1
    kind: PriorityClass
    metadata:
      name: test
    value: 1
    preemptionPolicy: Never
    globalDefault: false
    description: "my first priority class"
```
Here the previous version of the chart would generate two Kubernetes manifests, the first one resulting from the comment part ("# Create my priority class") before the first object separator "---".
The first document only contained the labels appended by the chart, something like that:
```
---
metadata:
  labels:
    app: raw
    chart: raw-1.0.2
    heritage: Helm
    release: raw
```
But this is an invalid Kubernetes manifest since it does not contain mandatory fields like `apiVersion` or `kind`, so applying the Helm release will result in an error.

This kind of use case with a comment being placed before the first separator "---" can occur when using a `range` loop that needs to be documented. Like that:
```
{{- range $key, $value:= .Values.priorityClasses }}
# An explanatory comment about what's coming below
---
apiVersion: scheduling.k8s.io/v1
kind: PriorityClass
metadata:
  name: {{ $key }}
value: {{ $value.priority }}
preemptionPolicy: Never
globalDefault: false
description: {{ $value.desc }}
{{- end }}
```